### PR TITLE
[feature/add-peekaboo-camera-module] Support Camera Integration for Image Selection

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
 appcompat = "1.6.1"
 material = "1.10.0"
+accompanist = "0.32.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -33,6 +34,7 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/peekaboo-camera/build.gradle.kts
+++ b/peekaboo-camera/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.composeMultiplatform)
+}
+
+kotlin {
+    androidTarget {
+        publishLibraryVariants("release")
+        compilations.all {
+            kotlinOptions {
+                jvmTarget = "11"
+            }
+        }
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+            implementation(compose.material)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
+        androidMain.dependencies {
+            implementation(libs.androidx.activity.compose)
+            implementation(libs.accompanist.permissions)
+        }
+    }
+}
+
+android {
+    namespace = "com.preat.peekaboo.camera"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    sourceSets["main"].res.srcDirs("src/androidMain/res")
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}

--- a/peekaboo-camera/src/androidMain/AndroidManifest.xml
+++ b/peekaboo-camera/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-feature android:name="android.hardware.camera.any"/>
+
+    <application>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/path_provider" />
+        </provider>
+
+    </application>
+</manifest>

--- a/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.android.kt
+++ b/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.android.kt
@@ -1,0 +1,88 @@
+package com.preat.peekaboo.camera
+
+import android.Manifest
+import android.content.Context
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberPermissionState
+import kotlinx.coroutines.CoroutineScope
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+actual fun rememberCameraCaptureLauncher(
+    scope: CoroutineScope,
+    onResult: (ByteArray?) -> Unit,
+    onCameraPermissionDenied: (() -> Unit)?,
+): CameraCaptureLauncher {
+    val context = LocalContext.current
+    val file = context.createImageFile()
+    val uri =
+        FileProvider.getUriForFile(
+            context,
+            context.packageName + ".provider",
+            file,
+        )
+
+    val cameraLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.TakePicture(),
+        ) { success ->
+            if (success) {
+                val imageBytes = file.readBytes()
+                onResult(imageBytes)
+            } else {
+                onResult(null)
+            }
+        }
+
+    val cameraPermissionState =
+        rememberPermissionState(
+            permission = Manifest.permission.CAMERA,
+            onPermissionResult = {
+                if (it) {
+                    cameraLauncher.launch(uri)
+                } else {
+                    onCameraPermissionDenied?.invoke()
+                }
+            },
+        )
+
+    return remember {
+        CameraCaptureLauncher(
+            onLaunch = {
+                cameraPermissionState.launchPermissionRequest()
+            },
+        )
+    }
+}
+
+actual class CameraCaptureLauncher actual constructor(
+    private val onLaunch: () -> Unit,
+) {
+    actual fun launch() {
+        onLaunch()
+    }
+}
+
+fun Context.createImageFile(): File {
+    // Generate a file name using the current time
+    val timeStamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.getDefault()).format(Date())
+    // Add a unique identifier to prevent file name duplication
+    val uniqueID = createUUID()
+    val imageFileName = "${timeStamp}_$uniqueID"
+
+    return File.createTempFile(
+        imageFileName,
+        ".jpg",
+        externalCacheDir,
+    )
+}

--- a/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.android.kt
+++ b/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.android.kt
@@ -1,0 +1,5 @@
+package com.preat.peekaboo.camera
+
+import java.util.UUID
+
+actual fun createUUID(): String = UUID.randomUUID().toString()

--- a/peekaboo-camera/src/androidMain/res/xml/path_provider.xml
+++ b/peekaboo-camera/src/androidMain/res/xml/path_provider.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-cache-path name="peekaboo_images" path="/"/>
+</paths>

--- a/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.kt
+++ b/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.kt
@@ -1,0 +1,17 @@
+package com.preat.peekaboo.camera
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+expect fun rememberCameraCaptureLauncher(
+    scope: CoroutineScope,
+    onResult: (ByteArray?) -> Unit,
+    onCameraPermissionDenied: (() -> Unit)?,
+): CameraCaptureLauncher
+
+expect class CameraCaptureLauncher(
+    onLaunch: () -> Unit,
+) {
+    fun launch()
+}

--- a/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.kt
+++ b/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.kt
@@ -1,0 +1,3 @@
+package com.preat.peekaboo.camera
+
+expect fun createUUID(): String

--- a/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.ios.kt
+++ b/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.ios.kt
@@ -1,0 +1,135 @@
+package com.preat.peekaboo.camera
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CoroutineScope
+import platform.AVFoundation.AVCaptureDevice
+import platform.AVFoundation.AVMediaTypeVideo
+import platform.AVFoundation.requestAccessForMediaType
+import platform.Foundation.NSData
+import platform.UIKit.UIApplication
+import platform.UIKit.UIImage
+import platform.UIKit.UIImagePNGRepresentation
+import platform.UIKit.UIImagePickerController
+import platform.UIKit.UIImagePickerControllerCameraCaptureMode
+import platform.UIKit.UIImagePickerControllerDelegateProtocol
+import platform.UIKit.UIImagePickerControllerOriginalImage
+import platform.UIKit.UIImagePickerControllerSourceType
+import platform.UIKit.UINavigationControllerDelegateProtocol
+import platform.darwin.NSObject
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+import platform.posix.memcpy
+
+@Composable
+actual fun rememberCameraCaptureLauncher(
+    scope: CoroutineScope,
+    onResult: (ByteArray?) -> Unit,
+    onCameraPermissionDenied: (() -> Unit)?,
+): CameraCaptureLauncher {
+    var cameraAccess: CameraAccess by remember { mutableStateOf(CameraAccess.Undefined) }
+    val delegate =
+        remember {
+            StrongReferenceDelegate(onResult)
+        }
+
+    return remember {
+        CameraCaptureLauncher(
+            onLaunch = {
+                when (cameraAccess) {
+                    CameraAccess.Undefined, CameraAccess.Denied -> {
+                        requestCameraPermission { granted ->
+                            if (granted) {
+                                cameraAccess = CameraAccess.Authorized
+                                launchCamera(delegate)
+                            } else {
+                                cameraAccess = CameraAccess.Denied
+                                onCameraPermissionDenied?.invoke()
+                            }
+                        }
+                    }
+                    CameraAccess.Authorized -> {
+                        launchCamera(delegate)
+                    }
+                }
+            },
+        )
+    }
+}
+
+class StrongReferenceDelegate(
+    private val onResult: (ByteArray?) -> Unit,
+) : NSObject(), UIImagePickerControllerDelegateProtocol, UINavigationControllerDelegateProtocol {
+    override fun imagePickerController(
+        picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo: Map<Any?, *>,
+    ) {
+        val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage
+        image?.let {
+            val imageBytes = UIImagePNGRepresentation(it)?.toByteArray()
+            onResult(imageBytes)
+        } ?: onResult(null)
+
+        picker.dismissViewControllerAnimated(true, null)
+    }
+
+    override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
+        picker.dismissViewControllerAnimated(true, null)
+    }
+}
+
+private fun launchCamera(delegate: StrongReferenceDelegate) {
+    dispatch_async(dispatch_get_main_queue()) {
+        val imagePickerController =
+            UIImagePickerController().apply {
+                sourceType = UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
+                cameraCaptureMode = UIImagePickerControllerCameraCaptureMode.UIImagePickerControllerCameraCaptureModePhoto
+            }
+        imagePickerController.delegate = delegate
+        UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
+            imagePickerController,
+            true,
+            completion = null,
+        )
+    }
+}
+
+private fun requestCameraPermission(onPermissionResult: (Boolean) -> Unit) {
+    AVCaptureDevice.requestAccessForMediaType(AVMediaTypeVideo) { granted ->
+        onPermissionResult(granted)
+    }
+}
+
+actual class CameraCaptureLauncher actual constructor(
+    private val onLaunch: () -> Unit,
+) {
+    actual fun launch() {
+        onLaunch()
+    }
+}
+
+private sealed interface CameraAccess {
+    data object Undefined : CameraAccess
+
+    data object Denied : CameraAccess
+
+    data object Authorized : CameraAccess
+}
+
+@OptIn(ExperimentalForeignApi::class)
+inline fun NSData.toByteArray(): ByteArray {
+    val size = length.toInt()
+    val byteArray = ByteArray(size)
+    if (size > 0) {
+        byteArray.usePinned { pinned ->
+            memcpy(pinned.addressOf(0), this.bytes, this.length)
+        }
+    }
+    return byteArray
+}

--- a/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.ios.kt
+++ b/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.ios.kt
@@ -1,0 +1,9 @@
+package com.preat.peekaboo.camera
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreFoundation.CFUUIDCreate
+import platform.CoreFoundation.CFUUIDCreateString
+import platform.Foundation.CFBridgingRelease
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun createUUID(): String = CFBridgingRelease(CFUUIDCreateString(null, CFUUIDCreate(null))) as String

--- a/sample/common/build.gradle.kts
+++ b/sample/common/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
 
                 // peekaboo
                 implementation(projects.peekabooImagePicker)
+                implementation(projects.peekabooCamera)
             }
         }
 

--- a/sample/ios/peekaboo.xcodeproj/project.pbxproj
+++ b/sample/ios/peekaboo.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses camera for capturing photos";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -332,6 +333,7 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses camera for capturing photos";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/sample/ios/peekaboo/peekabooApp.swift
+++ b/sample/ios/peekaboo/peekabooApp.swift
@@ -13,6 +13,7 @@ struct peekabooApp: App {
     var body: some Scene {
         WindowGroup {
             ComposeView()
+                .ignoresSafeArea(.all, edges: .bottom)
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ dependencyResolutionManagement {
 rootProject.name = "peekaboo"
 include(
     ":peekaboo-image-picker",
+    ":peekaboo-camera",
     ":sample:android",
     ":sample:common",
 )


### PR DESCRIPTION
## Overview
This pull request introduces the `peekaboo-camera` module to the project, providing a unified camera capture functionality across iOS and Android platforms.

## Changes
- Added the `peekaboo-camera` module to the project.
- Implemented `rememberCameraCaptureLauncher` for both iOS and Android.
   - However, it currently does not fully function on iOS. #15

close #9 
