### PR TITLE
[feature/add-permission-denied-content] Add `permissionDeniedContent` parameter to `PeekabooCamera` composable

### DIFF
--- a/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "io.github.team-preat"
-    version = "0.2.1"
+    version = "0.3.0"
 }
 
 nexusPublishing {

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.android.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.util.concurrent.Executors
@@ -45,11 +46,10 @@ actual fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit,
     progressIndicator: @Composable () -> Unit,
     onCapture: (byteArray: ByteArray?) -> Unit,
+    permissionDeniedContent: @Composable () -> Unit,
 ) {
     val cameraPermissionState =
-        rememberPermissionState(
-            android.Manifest.permission.CAMERA,
-        )
+        rememberPermissionState(permission = android.Manifest.permission.CAMERA)
     when (cameraPermissionState.status) {
         PermissionStatus.Granted -> {
             CameraWithGrantedPermission(
@@ -62,8 +62,14 @@ actual fun PeekabooCamera(
             )
         }
         is PermissionStatus.Denied -> {
-            LaunchedEffect(Unit) {
-                cameraPermissionState.launchPermissionRequest()
+            if (cameraPermissionState.status.shouldShowRationale) {
+                LaunchedEffect(Unit) {
+                    cameraPermissionState.launchPermissionRequest()
+                }
+            } else {
+                Box(modifier = modifier) {
+                    permissionDeniedContent()
+                }
             }
         }
     }

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/CameraMode.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/CameraMode.kt
@@ -1,7 +1,21 @@
 package com.preat.peekaboo.ui
 
+/**
+ * Represents the camera modes available in the `PeekabooCamera` composable.
+ * This sealed class is used to define whether the front or back camera should be used.
+ *
+ * `CameraMode` allows developers to specify the initial camera facing direction.
+ */
 sealed class CameraMode {
+    /**
+     * Represents the front-facing camera mode.
+     * Use this mode to utilize the device's front camera in the PeekabooCamera composable.
+     */
     data object Front : CameraMode()
 
+    /**
+     * Represents the back-facing camera mode.
+     * Use this mode to utilize the device's rear camera in the PeekabooCamera composable.
+     */
     data object Back : CameraMode()
 }

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.kt
@@ -13,6 +13,14 @@ import androidx.compose.ui.Modifier
  * @param convertIcon An optional composable lambda for a button to toggle the camera mode. It takes an `onClick` lambda for switching the camera.
  * @param progressIndicator An optional composable lambda displayed during photo capture processing.
  * @param onCapture A lambda called when a photo is captured, providing the photo as a ByteArray or null if the capture fails.
+ * @param permissionDeniedContent An optional composable lambda that provides content to be displayed when camera permission is denied.
+ *        This allows users to define a custom UI to inform or guide the user when camera access has been denied. The content can be
+ *        informative text, an image, a button to redirect the user to settings, or any other composable content. This lambda will be invoked
+ *        within the PeekabooCamera composable scope, replacing the camera preview with the user-defined UI.
+ *
+ * Note: If `permissionDeniedContent` is not used, and the camera permission is denied, PeekabooCamera will render an empty view. To avoid this,
+ * it's recommended to implement a separate permission check logic before rendering the PeekabooCamera composable. This way, you can ensure the
+ * camera permission is granted before the camera UI is displayed, or handle the permission denial appropriately outside of the PeekabooCamera scope.
  */
 @Suppress("FunctionName")
 @Composable
@@ -23,4 +31,5 @@ expect fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit = {},
     progressIndicator: @Composable () -> Unit = {},
     onCapture: (byteArray: ByteArray?) -> Unit,
+    permissionDeniedContent: @Composable () -> Unit = {},
 )

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.ios.kt
@@ -96,6 +96,7 @@ actual fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit,
     progressIndicator: @Composable () -> Unit,
     onCapture: (byteArray: ByteArray?) -> Unit,
+    permissionDeniedContent: @Composable () -> Unit,
 ) {
     var cameraAccess: CameraAccess by remember { mutableStateOf(CameraAccess.Undefined) }
     LaunchedEffect(Unit) {
@@ -130,7 +131,9 @@ actual fun PeekabooCamera(
             }
 
             CameraAccess.Denied -> {
-                Text("Camera access denied", color = Color.White)
+                Box(modifier = modifier) {
+                    permissionDeniedContent()
+                }
             }
 
             CameraAccess.Authorized -> {

--- a/sample/android/src/main/AndroidManifest.xml
+++ b/sample/android/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.preat.peekaboo.android">
 
     <application
+        android:label="peekaboo"
         android:allowBackup="false"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
@@ -1,9 +1,11 @@
 package com.preat.peekaboo.common
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -11,11 +13,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
@@ -32,11 +35,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.preat.peekaboo.common.component.CircularButton
 import com.preat.peekaboo.common.component.InstagramCameraButton
 import com.preat.peekaboo.common.icon.IconCached
 import com.preat.peekaboo.common.icon.IconClose
+import com.preat.peekaboo.common.icon.IconWarning
 import com.preat.peekaboo.common.style.PeekabooTheme
 import com.preat.peekaboo.image.picker.SelectionMode
 import com.preat.peekaboo.image.picker.rememberImagePickerLauncher
@@ -131,6 +136,28 @@ fun App() {
                                     }
                                     showCamera = false
                                 },
+                                permissionDeniedContent = {
+                                    Column(
+                                        modifier =
+                                            Modifier
+                                                .fillMaxSize()
+                                                .background(color = MaterialTheme.colors.background),
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center,
+                                    ) {
+                                        Icon(
+                                            imageVector = IconWarning,
+                                            contentDescription = "Warning Icon",
+                                            tint = MaterialTheme.colors.onBackground,
+                                        )
+                                        Spacer(modifier = Modifier.height(16.dp))
+                                        Text(
+                                            text = "Please grant the camera permission!",
+                                            color = MaterialTheme.colors.onBackground,
+                                            textAlign = TextAlign.Center,
+                                        )
+                                    }
+                                },
                             )
                         }
                         IconButton(
@@ -150,15 +177,18 @@ fun App() {
                         }
                     }
                 } else {
-                    LazyRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    LazyRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        contentPadding = PaddingValues(horizontal = 8.dp),
+                    ) {
                         items(images) { image ->
                             Image(
                                 bitmap = image,
                                 contentDescription = "Selected Image",
                                 modifier =
                                     Modifier
-                                        .size(100.dp)
-                                        .clip(CircleShape),
+                                        .size(200.dp)
+                                        .clip(shape = RoundedCornerShape(12.dp)),
                                 contentScale = ContentScale.Crop,
                             )
                         }

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconWarning.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconWarning.kt
@@ -1,0 +1,27 @@
+package com.preat.peekaboo.common.icon
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+
+internal val IconWarning =
+    materialIcon(name = "Filled.Warning") {
+        materialPath {
+            moveTo(1.0f, 21.0f)
+            horizontalLineToRelative(22.0f)
+            lineTo(12.0f, 2.0f)
+            lineTo(1.0f, 21.0f)
+            close()
+            moveTo(13.0f, 18.0f)
+            horizontalLineToRelative(-2.0f)
+            verticalLineToRelative(-2.0f)
+            horizontalLineToRelative(2.0f)
+            verticalLineToRelative(2.0f)
+            close()
+            moveTo(13.0f, 14.0f)
+            horizontalLineToRelative(-2.0f)
+            verticalLineToRelative(-4.0f)
+            horizontalLineToRelative(2.0f)
+            verticalLineToRelative(4.0f)
+            close()
+        }
+    }

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/style/Palette.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/style/Palette.kt
@@ -14,6 +14,10 @@ object PeekabooColors {
     val uiLightBlack = Color(25, 25, 28).copy(alpha = 0.7f)
     val darkBackground = Color(0xFF19191C)
     val darkOnBackground = Color(0xFFFFFFFF)
+    val primary = Color(0xFFE0E0E0)
+    val onPrimary = Color(0xFF000000)
+    val darkPrimary = Color(0xFF424242)
+    val darkOnPrimary = Color(0xFFFFFFFF)
 }
 
 @Suppress("FunctionName")
@@ -25,11 +29,15 @@ fun PeekabooTheme(content: @Composable () -> Unit) {
             MaterialTheme.colors.copy(
                 background = PeekabooColors.darkBackground,
                 onBackground = PeekabooColors.darkOnBackground,
+                primary = PeekabooColors.darkPrimary,
+                onPrimary = PeekabooColors.darkOnPrimary,
             )
         } else {
             MaterialTheme.colors.copy(
                 background = PeekabooColors.background,
                 onBackground = PeekabooColors.onBackground,
+                primary = PeekabooColors.primary,
+                onPrimary = PeekabooColors.onPrimary,
             )
         }
 

--- a/sample/ios/peekaboo.xcodeproj/project.pbxproj
+++ b/sample/ios/peekaboo.xcodeproj/project.pbxproj
@@ -307,7 +307,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -345,7 +345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",


### PR DESCRIPTION
## Changes
- Added `permissionDeniedContent` parameter to `PeekabooCamera` composable.
- Implemented a usage example in the sample app, showcasing how to use `permissionDeniedContent`.
- Updated the image UI size in the sample app for better layout presentation.

## Implementation Details
The `permissionDeniedContent` is a composable lambda that gets invoked within the `PeekabooCamera` scope when camera permission is denied. This parameter allows developers to define custom UI elements like informative text, images, or a button to redirect users to settings. If not used, the `PeekabooCamera` composable will render a empty screen when permission is denied. Therefore, it's recommended to implement this feature for a comprehensive user experience.
