### PR TITLE
[feature/add-license-headers] Add Apache 2.0 License Headers to All Files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
 import com.diffplug.gradle.spotless.SpotlessExtension
@@ -21,11 +36,13 @@ allprojects {
             target("**/*.kt")
             targetExclude("**/build/")
             ktlint(libs.versions.ktlint.get())
+            licenseHeaderFile(rootProject.file("spotless/copyright.txt"))
         }
         kotlinGradle {
             target("**/*.gradle.kts")
             targetExclude("**/build/")
             ktlint(libs.versions.ktlint.get())
+            licenseHeaderFile(rootProject.file("spotless/copyright.txt"), "(^(?![\\/ ]\\*).*$)")
         }
     }
 

--- a/convention-plugins/build.gradle.kts
+++ b/convention-plugins/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     `kotlin-dsl`
 }

--- a/convention-plugins/settings.gradle.kts
+++ b/convention-plugins/settings.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 pluginManagement {
     repositories {
         google()

--- a/convention-plugins/src/main/kotlin/module.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/module.publication.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.`maven-publish`

--- a/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     id("io.github.gradle-nexus.publish-plugin")
 }

--- a/peekaboo-camera/build.gradle.kts
+++ b/peekaboo-camera/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)

--- a/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.android.kt
+++ b/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.android.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.camera
 
 import android.Manifest

--- a/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.android.kt
+++ b/peekaboo-camera/src/androidMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.android.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.camera
 
 import java.util.UUID

--- a/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.kt
+++ b/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.camera
 
 import androidx.compose.runtime.Composable

--- a/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.kt
+++ b/peekaboo-camera/src/commonMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.camera
 
 expect fun createUUID(): String

--- a/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.ios.kt
+++ b/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/CameraCaptureLauncher.ios.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.camera
 
 import androidx.compose.runtime.Composable

--- a/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.ios.kt
+++ b/peekaboo-camera/src/iosMain/kotlin/com/preat/peekaboo/camera/UuidGenerator.ios.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.camera
 
 import kotlinx.cinterop.ExperimentalForeignApi

--- a/peekaboo-image-picker/build.gradle.kts
+++ b/peekaboo-image-picker/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)

--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ByteArrayToImageBitmap.android.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ByteArrayToImageBitmap.android.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.image.picker
 
 import android.graphics.BitmapFactory

--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ImagePicker.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ImagePicker.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.image.picker
 
 import android.annotation.SuppressLint

--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.android.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.android.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.image.picker
 
 import androidx.activity.compose.rememberLauncherForActivityResult

--- a/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ByteArrayToImageBitmap.kt
+++ b/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ByteArrayToImageBitmap.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.image.picker
 
 import androidx.compose.ui.graphics.ImageBitmap

--- a/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.kt
+++ b/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.image.picker
 
 import androidx.compose.runtime.Composable

--- a/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ByteArrayToImageBitmap.ios.kt
+++ b/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ByteArrayToImageBitmap.ios.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.image.picker
 
 import androidx.compose.ui.graphics.ImageBitmap

--- a/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
+++ b/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.image.picker
 
 import androidx.compose.runtime.Composable

--- a/peekaboo-ui/build.gradle.kts
+++ b/peekaboo-ui/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/ImageViewerFileProvider.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/ImageViewerFileProvider.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.ui
 
 import androidx.core.content.FileProvider

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.android.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.ui
 
 import android.graphics.Bitmap

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/CameraMode.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/CameraMode.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.ui
 
 /**

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.ui
 
 import androidx.compose.runtime.Composable

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/CameraAccess.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/CameraAccess.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.ui
 
 internal sealed interface CameraAccess {

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/PeekabooCamera.ios.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.ui
 
 import androidx.compose.foundation.background

--- a/sample/android/build.gradle.kts
+++ b/sample/android/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.androidApplication)

--- a/sample/android/src/androidTest/java/com/preat/peekaboo/android/ExampleInstrumentedTest.kt
+++ b/sample/android/src/androidTest/java/com/preat/peekaboo/android/ExampleInstrumentedTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.android
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/sample/android/src/main/java/com/preat/peekaboo/sample/MainActivity.kt
+++ b/sample/android/src/main/java/com/preat/peekaboo/sample/MainActivity.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.sample
 
 import android.os.Bundle

--- a/sample/common/build.gradle.kts
+++ b/sample/common/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeMultiplatform)

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common
 
 import androidx.compose.foundation.Image

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/TopLayout.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/TopLayout.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common
 
 import androidx.compose.foundation.layout.Box

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/CircularButton.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/CircularButton.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.component
 
 import androidx.compose.foundation.background

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/InstagramCameraButton.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/InstagramCameraButton.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.component
 
 import androidx.compose.foundation.BorderStroke

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconArrowLeft.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconArrowLeft.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.icon
 
 import androidx.compose.material.icons.materialIcon

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconCached.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconCached.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.icon
 
 import androidx.compose.material.icons.materialIcon

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconClose.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconClose.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.icon
 
 import androidx.compose.material.icons.materialIcon

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconPhotoCamera.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconPhotoCamera.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.icon
 
 import androidx.compose.material.icons.materialIcon

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconWarning.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/icon/IconWarning.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.icon
 
 import androidx.compose.material.icons.materialIcon

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/style/Palette.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/style/Palette.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.preat.peekaboo.common.style
 
 import androidx.compose.foundation.isSystemInDarkTheme

--- a/sample/common/src/iosMain/kotlin/com/preat/peekaboo/common/Main.ios.kt
+++ b/sample/common/src/iosMain/kotlin/com/preat/peekaboo/common/Main.ios.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import androidx.compose.ui.window.ComposeUIViewController
 import com.preat.peekaboo.common.App
 import platform.UIKit.UIViewController

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     includeBuild("convention-plugins")

--- a/spotless/copyright.txt
+++ b/spotless/copyright.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright $YEAR onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.preat.peekaboo.android
-
-import org.junit.Assert.assertEquals
-import org.junit.Test
-
-/**
- * Example local unit test, which will execute on the development machine (host).
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
-class ExampleUnitTest {
-    @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
-    }
-}


### PR DESCRIPTION
## Changes
- Implemented the `licenseHeaderFile` configuration in Gradle build script, utilizing the Spotless plugin.
- Applied the `Apache 2.0 License` header to all Kotlin source files (`*.kt`) and Kotlin Gradle script files (`*.gradle.kts`).
- Adjusted the Spotless plugin configuration to target all relevant files and exclude any build directories.

close #24 