### PR TITLE
[feature/add-ci-ignore-md] Ignore Markdown Files in CI Workflow

### DIFF
--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -3,8 +3,12 @@ name: Check CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Changes
- This PR updates the CI workflow to ignore changes in Markdown files, thereby preventing unnecessary CI runs for documentation updates.