### PR TITLE
[Fix] Resolved INSTALL_FAILED_CONFLICTING_PROVIDER issue

### DIFF
--- a/peekaboo-ui/src/androidMain/AndroidManifest.xml
+++ b/peekaboo-ui/src/androidMain/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <application>
         <provider
             android:name="com.preat.peekaboo.ui.ImageViewerFileProvider"
-            android:authorities="com.preat.peekaboo.fileprovider"
+            android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true" />
     </application>


### PR DESCRIPTION
**Issues Resolved:**  [ #31 ]

This pull request specifically addresses the **INSTALL_FAILED_CONFLICTING_PROVIDER** issue, allowing for a smoother installation process. The changes made ensure that the library can be implemented in multiple projects without encountering conflicting provider errors, and installations across different apps on the same device are now error-free.

**Changes Made:**
- Replaced hardcoded package name with applicationId in the manifest file of **peekaboo-ui**.

**Benefits:**
- Resolves the **INSTALL_FAILED_CONFLICTING_PROVIDER** issue.
- Enhances compatibility for implementing the library in multiple projects.
