### PR TITLE
[fix/image-picker-launcher-duplicate-call-prevention] Implement duplicate call prevention in ImagePickerLauncher(Android)

### DIFF
--- a/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 
 allprojects {
     group = "io.github.team-preat"
-    version = "0.3.2"
+    version = "0.3.3"
 }
 
 nexusPublishing {

--- a/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.kt
+++ b/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.CoroutineScope
 @Composable
 expect fun rememberImagePickerLauncher(
     selectionMode: SelectionMode = SelectionMode.Single,
-    scope: CoroutineScope?,
+    scope: CoroutineScope,
     resizeOptions: ResizeOptions = ResizeOptions(),
     onResult: (List<ByteArray>) -> Unit,
 ): ImagePickerLauncher

--- a/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
+++ b/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
@@ -49,7 +49,7 @@ import platform.posix.memcpy
 @Composable
 actual fun rememberImagePickerLauncher(
     selectionMode: SelectionMode,
-    scope: CoroutineScope?,
+    scope: CoroutineScope,
     resizeOptions: ResizeOptions,
     onResult: (List<ByteArray>) -> Unit,
 ): ImagePickerLauncher {
@@ -71,7 +71,7 @@ actual fun rememberImagePickerLauncher(
                     result.itemProvider.loadDataRepresentationForTypeIdentifier(
                         typeIdentifier = "public.image",
                     ) { nsData, _ ->
-                        scope?.launch(Dispatchers.Main) {
+                        scope.launch(Dispatchers.Main) {
                             nsData?.let {
                                 val image = UIImage.imageWithData(it)
                                 val resizedImage = image?.fitInto(resizeOptions.width, resizeOptions.height)
@@ -86,7 +86,7 @@ actual fun rememberImagePickerLauncher(
                 }
 
                 dispatch_group_notify(dispatchGroup, platform.darwin.dispatch_get_main_queue()) {
-                    scope?.launch(Dispatchers.Main) {
+                    scope.launch(Dispatchers.Main) {
                         onResult(imageData)
                     }
                 }


### PR DESCRIPTION
## Changes
Modified the `launch()` in `ImagePickerLauncher` method to check the `isPhotoPickerActive` flag. If the picker is active in Android, it prevents further executions of `onLaunch()`.
