### PR TITLE
[feature/optimize-memory-cache] Implementation of Memory Cache Optimization for Image Picking in Android

### DIFF
--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooBitmapCache.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooBitmapCache.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 onseok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.preat.peekaboo.image.picker
+
+import android.graphics.Bitmap
+import android.util.LruCache
+import java.io.ByteArrayOutputStream
+
+internal object PeekabooBitmapCache {
+    internal val instance: LruCache<String, Bitmap> by lazy {
+        LruCache<String, Bitmap>(calculateMemoryCacheSize())
+    }
+
+    private fun calculateMemoryCacheSize(): Int {
+        val maxMemory = Runtime.getRuntime().maxMemory() / 1024
+        val cacheSize = (maxMemory * 0.25).toInt()
+        return cacheSize.coerceAtLeast(1024 * 1024)
+    }
+
+    internal fun bitmapToByteArray(bitmap: Bitmap): ByteArray {
+        ByteArrayOutputStream().use { stream ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+            return stream.toByteArray()
+        }
+    }
+}


### PR DESCRIPTION
close #35 

## Changes 
- `PeekabooBitmapCache`: Implemented a new singleton class `PeekabooBitmapCache` to handle memory caching of bitmap images in Android. This class utilizes an `LruCache` to store and retrieve bitmap images efficiently, optimizing memory usage for image picking.

- `Memory Cache Size Calculation`: Implemented a method within `PeekabooBitmapCache` to calculate the optimal cache size based on the available runtime memory. The cache size is set to `25%` of the maximum available memory, with a minimum threshold of 1MB, and this `25%` allocation is inspired by the memory caching policy used in the [qdsfdhvh/compose-imageloader](https://github.com/qdsfdhvh/compose-imageloader) project.