### PR TITLE
[fix/ios-image-aspect-ratio] Maintain Aspect Ratio for Image Resizing on iOS

### DIFF
--- a/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
+++ b/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
@@ -130,12 +130,28 @@ private fun UIImage.toByteArray(): ByteArray {
 
 @OptIn(ExperimentalForeignApi::class)
 private fun UIImage.fitInto(
-    width: Int,
-    height: Int,
+    maxWidth: Int,
+    maxHeight: Int,
     filterOptions: FilterOptions,
 ): UIImage {
-    val targetSize = CGSizeMake(width.toDouble(), height.toDouble())
+    val originalWidth = this.size.useContents { width }
+    val originalHeight = this.size.useContents { height }
+    val originalRatio = originalWidth / originalHeight
+
+    val targetRatio = maxWidth.toDouble() / maxHeight.toDouble()
+    val scale =
+        if (originalRatio > targetRatio) {
+            maxWidth.toDouble() / originalWidth
+        } else {
+            maxHeight.toDouble() / originalHeight
+        }
+
+    val newWidth = originalWidth * scale
+    val newHeight = originalHeight * scale
+
+    val targetSize = CGSizeMake(newWidth, newHeight)
     val resizedImage = this.resize(targetSize)
+
     return applyFilterToUIImage(resizedImage, filterOptions)
 }
 


### PR DESCRIPTION
## Changes
- Modified the `UIImage.fitInto` function to ensure the original aspect ratio of images is maintained during resizing on iOS.

close #44 
